### PR TITLE
update nyc-taxi csv dataset location

### DIFF
--- a/nyc-taxi/nyc-taxi-fhv-all.sql
+++ b/nyc-taxi/nyc-taxi-fhv-all.sql
@@ -5,8 +5,8 @@ LOAD TABLE nyc_taxi.nyc_taxi_trips_fhv
     pu_location_id VARCHAR(max)
   )
   FROM (
-    '/trip data/fhv_tripdata_2015',
-    '/trip data/fhv_tripdata_2016'
+    '/csv_backup/fhv_tripdata_2015',
+    '/csv_backup/fhv_tripdata_2016'
   )
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
@@ -24,7 +24,7 @@ LOAD TABLE nyc_taxi.nyc_taxi_trips_fhv
     dispatching_base_num VARCHAR(max)
   )
   FROM (
-    '/trip data/fhv_tripdata_2018'
+    '/csv_backup/fhv_tripdata_2018'
   )
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
@@ -34,9 +34,9 @@ LOAD TABLE nyc_taxi.nyc_taxi_trips_fhv
 
 LOAD TABLE nyc_taxi.nyc_taxi_trips_fhv
   FROM (
-    '/trip data/fhv_tripdata_2017',
-    '/trip data/fhv_tripdata_2019',
-    '/trip data/fhv_tripdata_202'
+    '/csv_backup/fhv_tripdata_2017',
+    '/csv_backup/fhv_tripdata_2019',
+    '/csv_backup/fhv_tripdata_202'
   )
   EXTERNAL LOCATION nyc_taxi_location
   WITH (

--- a/nyc-taxi/nyc-taxi-fhv-one-month.sql
+++ b/nyc-taxi/nyc-taxi-fhv-one-month.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_fhv
-  FROM ('/trip data/fhv_tripdata_2019-01.csv')
+  FROM ('/csv_backup/fhv_tripdata_2019-01.csv')
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
     max_bad_rows '-1' );

--- a/nyc-taxi/nyc-taxi-fhv-one-year.sql
+++ b/nyc-taxi/nyc-taxi-fhv-one-year.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_fhv
-  FROM ('/trip data/fhv_tripdata_2019')
+  FROM ('/csv_backup/fhv_tripdata_2019')
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
     num_readers '30',

--- a/nyc-taxi/nyc-taxi-fhvhv-all.sql
+++ b/nyc-taxi/nyc-taxi-fhvhv-all.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_fhvhv
-  FROM ('/trip data/fhvhv_tripdata')
+  FROM ('/csv_backup/fhvhv_tripdata')
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
     num_readers '30',

--- a/nyc-taxi/nyc-taxi-fhvhv-one-month.sql
+++ b/nyc-taxi/nyc-taxi-fhvhv-one-month.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_fhvhv
-  FROM ('/trip data/fhvhv_tripdata_2019-02.csv')
+  FROM ('/csv_backup/fhvhv_tripdata_2019-02.csv')
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
     max_bad_rows '-1' );

--- a/nyc-taxi/nyc-taxi-fhvhv-one-year.sql
+++ b/nyc-taxi/nyc-taxi-fhvhv-one-year.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_fhvhv
-  FROM ('/trip data/fhvhv_tripdata_2019')
+  FROM ('/csv_backup/fhvhv_tripdata_2019')
   EXTERNAL LOCATION nyc_taxi_location
   WITH (
     num_readers '30',

--- a/nyc-taxi/nyc-taxi-green-all.sql
+++ b/nyc-taxi/nyc-taxi-green-all.sql
@@ -1,10 +1,10 @@
 -- NB: green taxi data changed schema in 2016
 LOAD TABLE nyc_taxi.nyc_taxi_trips_green
   FROM (
-    'trip data/green_tripdata_2017',
-    'trip data/green_tripdata_2018',
-    'trip data/green_tripdata_2019',
-    'trip data/green_tripdata_202'
+    'csv_backup/green_tripdata_2017',
+    'csv_backup/green_tripdata_2018',
+    'csv_backup/green_tripdata_2019',
+    'csv_backup/green_tripdata_202'
   )
   EXTERNAL LOCATION nyc_taxi_location
   EXTERNAL FORMAT nyc_taxi_trips_green_yellow_format

--- a/nyc-taxi/nyc-taxi-green-one-month.sql
+++ b/nyc-taxi/nyc-taxi-green-one-month.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_green
-    FROM ('/trip data/green_tripdata_2020-01.csv')
+    FROM ('/csv_backup/green_tripdata_2020-01.csv')
     EXTERNAL LOCATION nyc_taxi_location
     EXTERNAL FORMAT nyc_taxi_trips_green_yellow_format
     WITH (max_bad_rows '-1')

--- a/nyc-taxi/nyc-taxi-yellow-all.sql
+++ b/nyc-taxi/nyc-taxi-yellow-all.sql
@@ -1,10 +1,10 @@
 -- NB: yellow taxi data changed schema in 2016
 LOAD TABLE nyc_taxi.nyc_taxi_trips_yellow
   FROM (
-    'trip data/yellow_tripdata_2017',
-    'trip data/yellow_tripdata_2018',
-    'trip data/yellow_tripdata_2019',
-    'trip data/yellow_tripdata_202'
+    'csv_backup/yellow_tripdata_2017',
+    'csv_backup/yellow_tripdata_2018',
+    'csv_backup/yellow_tripdata_2019',
+    'csv_backup/yellow_tripdata_202'
   )
   EXTERNAL LOCATION nyc_taxi_location
   EXTERNAL FORMAT nyc_taxi_trips_green_yellow_format

--- a/nyc-taxi/nyc-taxi-yellow-one-month.sql
+++ b/nyc-taxi/nyc-taxi-yellow-one-month.sql
@@ -1,5 +1,5 @@
 LOAD TABLE nyc_taxi.nyc_taxi_trips_yellow
-    FROM ('trip data/yellow_tripdata_2020-01.csv')
+    FROM ('csv_backup/yellow_tripdata_2020-01.csv')
     EXTERNAL LOCATION nyc_taxi_location
     EXTERNAL FORMAT nyc_taxi_trips_green_yellow_format
     WITH (max_bad_rows '-1')


### PR DESCRIPTION
AWS recently moved the csv data to a backup folder, default dataset format became parquet.